### PR TITLE
update: integrity check when sending file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ It uses the [quic-go](https://github.com/quic-go/quic-go) library to implement Q
 
 ## Features
 
-- Open 
+- Open multiple transactions over a single connection
+- Send and receive bytes message
+- Send and receive file
+- Send and receive file with bytes message
 
 ## Usage
 

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -1,7 +1,15 @@
 package error
 
+import "errors"
+
 const (
 	ConnectionClosedByPeer = "Application error 0x0 (remote): Connection closed by peer"
 
 	NoRecentActivity = "timeout: no recent network activity"
+
+	FileModifiedDuringTransferCode = 0x1
+)
+
+var (
+	ErrFileModifiedDuringTransfer = errors.New("file modified during transfer")
 )


### PR DESCRIPTION
**Which issue(s) this PR is related**:
Related: #8 

**What this PR does / Why we need it**:
Previously, it was not possible to check if a file changed during file transfer.
Therefore, after transferring the file, check whether the file has been changed and add code to cancel stream write.

**Additional notes for your reviewer**:
Since it simply cancels the stream write when the file changes, it would be good to consider upgrading it in the future.

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything