### PR TITLE
add: error return on transactionHandlerFunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ func main() {
 	* [Dial](#dial)
 	* [DialWithTransaction](#dialwithtransaction)
 	* [Close](#close)
+	* [RecvTransactionHandleFunc](#recvtransactionhandlefunc)
+	* [DefaultRecvTransactionHandleFunc](#defaultrecvtransactionhandlefunc)
+	* [GetErrChan](#geterrchan)
 * [Connection](#connection)
 	* [New](#new-1)
 	* [OpenTransaction](#opentransaction)
@@ -303,7 +306,7 @@ Close closes the quics-protocol instance.
 #### RecvTransactionHandleFunc
 
 ```go
-func (q *QP) RecvTransactionHandleFunc(transactionName string, callback func(conn *Connection, stream *Stream, transactionName string, transactionID []byte)) error
+func (q *QP) RecvTransactionHandleFunc(transactionName string, callback func(conn *Connection, stream *Stream, transactionName string, transactionID []byte) error) error
 ```
 
 RecvTransactionHandleFunc sets the handler function for receiving transactions from the client. The transaction name and callback function are needed as parameters. The transaction name is used to determine which handler to use on the receiving side.
@@ -311,10 +314,19 @@ RecvTransactionHandleFunc sets the handler function for receiving transactions f
 #### DefaultRecvTransactionHandleFunc
 
 ```go
-func (q *QP) DefaultRecvTransactionHandleFunc(callback func(conn *Connection, stream *Stream, transactionName string, transactionID []byte)) error
+func (q *QP) DefaultRecvTransactionHandleFunc(callback func(conn *Connection, stream *Stream, transactionName string, transactionID []byte) error) error
 ```
 
 DefaultRecvTransactionHandleFunc sets the default handler function for receiving transactions from the client. The callback function is needed as a parameter. The default handler is used when the transaction name is not set or the transaction name is not found.
+
+#### GetErrChan
+
+```go
+func (q *QP) GetErrChan() chan error
+```
+
+GetErrChan returns the error channel of the quics-protocol instance. The error channel is used to receive errors that occur in the receiving transaction handler function(The function that is set by RecvTransactionHandleFunc or DefaultRecvTransactionHandleFunc).
+This is optional. If you do not need to receive errors, you do not need to use this channel.
 
 ### Connection
 

--- a/README.md
+++ b/README.md
@@ -55,40 +55,41 @@ func main() {
 		log.Println("quics-server: ", err)
 	}
 
-	err = quicServer.RecvTransactionHandleFunc("test", func(conn *qp.Connection, stream *qp.Stream, transactionName string, transactionID []byte) {
+	err = quicServer.RecvTransactionHandleFunc("test", func(conn *qp.Connection, stream *qp.Stream, transactionName string, transactionID []byte) error {
 		log.Println("quics-server: ", "message received ", conn.Conn.RemoteAddr().String())
 
 		data, err := stream.RecvBMessage()
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "recv message from client")
 		log.Println("quics-server: ", "message: ", string(data))
 		if string(data) != "send message" {
 			log.Println("quics-server: Recieved message is not inteded message.")
-			return
+			return err
 		}
 
 		err = stream.SendBMessage([]byte("return message"))
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 
 		fileInfo, fileContent, err := stream.RecvFile()
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "file received")
 
 		err = fileInfo.WriteFileWithInfo("example/server/received.txt", fileContent)
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "file saved")
+		return nil
 	})
 	if err != nil {
 		log.Println("quics-server: ", err)
@@ -108,6 +109,8 @@ func main() {
 		log.Println("quics-server: ", "new connection ", conn.Conn.RemoteAddr().String())
 	})
 }
+
+
 ```
 
 ### Client

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -15,40 +15,41 @@ func main() {
 		log.Println("quics-server: ", err)
 	}
 
-	err = quicServer.RecvTransactionHandleFunc("test", func(conn *qp.Connection, stream *qp.Stream, transactionName string, transactionID []byte) {
+	err = quicServer.RecvTransactionHandleFunc("test", func(conn *qp.Connection, stream *qp.Stream, transactionName string, transactionID []byte) error {
 		log.Println("quics-server: ", "message received ", conn.Conn.RemoteAddr().String())
 
 		data, err := stream.RecvBMessage()
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "recv message from client")
 		log.Println("quics-server: ", "message: ", string(data))
 		if string(data) != "send message" {
 			log.Println("quics-server: Recieved message is not inteded message.")
-			return
+			return err
 		}
 
 		err = stream.SendBMessage([]byte("return message"))
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 
 		fileInfo, fileContent, err := stream.RecvFile()
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "file received")
 
 		err = fileInfo.WriteFileWithInfo("example/server/received.txt", fileContent)
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "file saved")
+		return nil
 	})
 	if err != nil {
 		log.Println("quics-server: ", err)

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -14,20 +14,23 @@ type Handler struct {
 	logLevel           int
 	ctx                context.Context
 	cancel             context.CancelFunc
-	transactionHandler map[string]func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, data []byte)
+	errChan            chan error
+	transactionHandler map[string]func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, data []byte) error
 }
 
 func New(loglevel int, ctx context.Context, cancel context.CancelFunc) *Handler {
-	transactionHandler := make(map[string]func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, data []byte))
+	transactionHandler := make(map[string]func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, data []byte) error)
 
-	transactionHandler["default"] = func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, data []byte) {
+	transactionHandler["default"] = func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, data []byte) error {
 		log.Println("quics-protocol: 'default' handler is not set")
+		return nil
 	}
 
 	return &Handler{
 		logLevel:           loglevel,
 		ctx:                ctx,
 		cancel:             cancel,
+		errChan:            nil,
 		transactionHandler: transactionHandler,
 	}
 }
@@ -54,9 +57,23 @@ func (h *Handler) RouteTransaction(conn *qpConn.Connection) error {
 			}
 			if h.transactionHandler[transaction.TransactionName] == nil {
 				log.Println("quics-protocol: ", "handler for transaction ", transaction.TransactionName, " is not set. Use 'default' handler.")
-				h.transactionHandler["default"](conn, stream, transaction.TransactionName, transaction.TransactionID)
+				err = h.transactionHandler["default"](conn, stream, transaction.TransactionName, transaction.TransactionID)
+				if err != nil {
+					log.Println("quics-protocol: ", err)
+					if h.errChan != nil {
+						h.errChan <- err
+					}
+					stream.Close()
+				}
 			} else {
-				h.transactionHandler[transaction.TransactionName](conn, stream, transaction.TransactionName, transaction.TransactionID)
+				err = h.transactionHandler[transaction.TransactionName](conn, stream, transaction.TransactionName, transaction.TransactionID)
+				if err != nil {
+					log.Println("quics-protocol: ", err)
+					if h.errChan != nil {
+						h.errChan <- err
+					}
+					stream.Close()
+				}
 			}
 		}()
 	}
@@ -81,7 +98,12 @@ func (h *Handler) RecvTransaction(conn *qpConn.Connection) (*qpStream.Stream, er
 	return newStream, nil
 }
 
-func (h *Handler) AddTransactionHandleFunc(transactionName string, handler func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, transactionID []byte)) error {
+func (h *Handler) GetErrChan() chan error {
+	h.errChan = make(chan error)
+	return h.errChan
+}
+
+func (h *Handler) AddTransactionHandleFunc(transactionName string, handler func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, transactionID []byte) error) error {
 	if transactionName == "default" {
 		return fmt.Errorf("quics-protocol: 'default' is reserved transaction name")
 	}
@@ -89,7 +111,7 @@ func (h *Handler) AddTransactionHandleFunc(transactionName string, handler func(
 	return nil
 }
 
-func (h *Handler) DefaultTransactionHandleFunc(handler func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, transactionID []byte)) error {
+func (h *Handler) DefaultTransactionHandleFunc(handler func(conn *qpConn.Connection, stream *qpStream.Stream, transactionName string, transactionID []byte) error) error {
 	h.transactionHandler["default"] = handler
 	return nil
 }

--- a/quics-protocol.go
+++ b/quics-protocol.go
@@ -245,7 +245,7 @@ func (q *QP) Close() error {
 // RecvTransactionHandleFunc sets the handler function for receiving transactions from the client.
 // The transaction name and callback function are needed as parameters.
 // The transaction name is used to determine which handler to use on the receiving side.
-func (q *QP) RecvTransactionHandleFunc(transactionName string, callback func(conn *Connection, stream *Stream, transactionName string, transactionID []byte)) error {
+func (q *QP) RecvTransactionHandleFunc(transactionName string, callback func(conn *Connection, stream *Stream, transactionName string, transactionID []byte) error) error {
 	err := q.handler.AddTransactionHandleFunc(transactionName, callback)
 	if err != nil {
 		return err
@@ -256,10 +256,17 @@ func (q *QP) RecvTransactionHandleFunc(transactionName string, callback func(con
 // DefaultRecvTransactionHandleFunc sets the default handler function for receiving transactions from the client.
 // The callback function is needed as a parameter.
 // The default handler is used when the transaction name is not set or the transaction name is not found.
-func (q *QP) DefaultRecvTransactionHandleFunc(callback func(conn *Connection, stream *Stream, transactionName string, transactionID []byte)) error {
+func (q *QP) DefaultRecvTransactionHandleFunc(callback func(conn *Connection, stream *Stream, transactionName string, transactionID []byte) error) error {
 	err := q.handler.DefaultTransactionHandleFunc(callback)
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+// GetErrChan returns the error channel of the quics-protocol instance.
+// This channel is used to receive errors when errors occur in the receive transaction handler function.
+// This is optional. If you do not need to receive errors, you do not need to use this channel.
+func (q *QP) GetErrChan() chan error {
+	return q.handler.GetErrChan()
 }

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -113,41 +113,42 @@ func runServer(t *testing.T) (*qp.QP, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = quicServer.RecvTransactionHandleFunc("test", func(conn *qp.Connection, stream *qp.Stream, transactionName string, transactionID []byte) {
+	err = quicServer.RecvTransactionHandleFunc("test", func(conn *qp.Connection, stream *qp.Stream, transactionName string, transactionID []byte) error {
 		defer wg.Done()
 		log.Println("quics-server: ", "message received ", conn.Conn.RemoteAddr().String())
 
 		data, err := stream.RecvBMessage()
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "recv message from client")
 		log.Println("quics-server: ", "message: ", string(data))
 		if string(data) != "send message" {
 			log.Println("quics-server: Recieved message is not inteded message.")
-			return
+			return err
 		}
 
 		err = stream.SendBMessage([]byte("return message"))
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 
 		fileInfo, fileContent, err := stream.RecvFile()
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "file received")
 
 		err = fileInfo.WriteFileWithInfo("received/test.txt", fileContent)
 		if err != nil {
 			log.Println("quics-server: ", err)
-			return
+			return err
 		}
 		log.Println("quics-server: ", "file saved")
+		return nil
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Which issue(s) this PR is related**:
Related: #1 

**What this PR does / Why we need it**:
Add an error as a return value to the receiving transaction handler. Through this, errors that occur while handling incoming transactions can be returned.
This error can be received through the error channel passed through GetErrChan.

**Additional notes for your reviewer**:

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything